### PR TITLE
Improve handling of multiple input files

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,12 +11,7 @@ function gulpProtractorCucumberHtmlReport(opts) {
   var currentDir = __dirname;
 
   opts = opts || {};
-  if (!opts.dest) {
-    opts.dest = '.';
-  }
-  if (!opts.filename) {
-    opts.filename = 'report.html';
-  }
+
   opts.templates = {
     featureTemplate: path.join(currentDir, './templates/feature_template.html'),
     headerTemplate: path.join(currentDir, './templates/header_template.html'),
@@ -33,17 +28,24 @@ function gulpProtractorCucumberHtmlReport(opts) {
     }
 
     if (file.isBuffer()) {
+      if (!opts.dest) {
+        opts.dest = __dirname;
+      }
+      if (!opts.filename) {
+        opts.filename = path.basename(gutil.replaceExtension(file.path, '.html'));
+      }
       var testResults = JSON.parse(file.contents);
 
-      fs.open(opts.dest + '/' + opts.filename, 'w+', function (err, fd) {
+      var output = path.join(opts.dest, opts.filename);
+      fs.open(output, 'w+', function (err, fd) {
         if (err) {
           fs.mkdirsSync(opts.dest);
-          fd = fs.openSync(opts.dest + '/' + opts.filename, 'w+');
+          fd = fs.openSync(output, 'w+');
         }
         fs.writeSync(fd, formatter.generateReport(testResults, opts.templates));
-        fs.copySync(currentDir + '/templates/assets', opts.dest + '/assets/');
+        fs.copySync(path.join(__dirname, 'templates', 'assets'), path.join(opts.dest, 'assets'));
 
-        gutil.log(PLUGIN_NAME + ':', 'File \'' + opts.filename + '\' has been created in \'' + opts.dest + '\' directory');
+        gutil.log(PLUGIN_NAME + ':', 'HTML report has been created in', gutil.colors.cyan(output));
 
         cb(null, file);
       });

--- a/index.js
+++ b/index.js
@@ -29,6 +29,7 @@ function gulpProtractorCucumberHtmlReport(opts) {
   return through.obj(function (file, enc, cb) {
     if (file.isNull()) {
       cb(null, file);
+      return;
     }
 
     if (file.isBuffer()) {
@@ -44,7 +45,7 @@ function gulpProtractorCucumberHtmlReport(opts) {
 
         gutil.log(PLUGIN_NAME + ':', 'File \'' + opts.filename + '\' has been created in \'' + opts.dest + '\' directory');
 
-        cb(null, file)
+        cb(null, file);
       });
 
     } else {

--- a/package.json
+++ b/package.json
@@ -33,18 +33,19 @@
     "templates"
   ],
   "dependencies": {
-    "fs-extra": "^0.24.0",
+    "fs-extra": "^0.26.3",
     "gulp-util": "^3.0.0",
     "lodash.template": "^3.6.2",
-    "through2": "^0.6.1"
+    "through2": "^2.0.0"
   },
   "devDependencies": {
     "chai": "^3.2.0",
     "gulp": "^3.9.0",
-    "gulp-jshint": "^1.11.2",
+    "gulp-jshint": "^2.0.0",
+    "jshint": "^2.8.0",
     "jshint-stylish": "^2.0.1",
     "mocha": "^2.2.5",
-    "vinyl": "^0.5.0"
+    "vinyl": "^1.1.0"
   },
   "keywords": [
     "gulpplugin"

--- a/test/test.js
+++ b/test/test.js
@@ -19,13 +19,14 @@ describe('gulp-protractor-cucumber-html-report', function() {
 
       var jsonFileBuffer = fs.readFileSync(path.join(__dirname, './data/cucumber_report.json'));
       var jsonFile = new File({
-        contents: jsonFileBuffer
+        contents: jsonFileBuffer,
+        path: path.join(__dirname, './data/cucumber_report.json')
       });
 
       var expectedReportBuffer = fs.readFileSync(path.join(__dirname, './data/expected_report.html'));
 
       stream.on('data', function () {
-        var resultBuffer = fs.readFileSync(outputFolder + '/report.html');
+        var resultBuffer = fs.readFileSync(outputFolder + '/cucumber_report.html');
 
         assert.equal(resultBuffer.toString(), expectedReportBuffer.toString());
       });


### PR DESCRIPTION
The output filename was set to 'report.html' by default, which is a problem when generating report for multiple input files at once. Because the output filename did not change, the HTML reports overwrite
each other.

The solution is to match the output to the input filename. So an input file called 'foo.json' will result in foo.html output. Thankfully gulp-util's `replaceFileExtension()` method makes this very easy.

Along the way I changed the creation of the paths to use Node's own `path` library. I think that should make things more reliable in different operating systems.
