### PR TITLE
Fix example with fs-extra in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ gulp.src('./cucumber-test-results.json')
 ```
 
 #### Saving CucumberJS JSON to disk when using Protractor
-If you're using Protractor in combination with CucumberJS there currently is [no way](https://github.com/cucumber/cucumber-js/issues/90) to save the CucumberJS JSON output to a file. 
- 
+If you're using Protractor in combination with CucumberJS there currently is [no way](https://github.com/cucumber/cucumber-js/issues/90) to save the CucumberJS JSON output to a file.
+
 It is however possible to add a listener to the CucumberJS JSON formatter and save it to a file manually. The following hook can be added to your project and included to your Protractor configuration.
 
 I've added 2 different hooks which basically do the same but one of the 2 requires you to add an extra dependency to your package.json. You're free to choose which one you prefer.
@@ -111,20 +111,20 @@ var Cucumber = require('cucumber');
 
 var JsonFormatter = Cucumber.Listener.JsonFormatter();
 
-var reportFile = ''../../reports/cucumber-test-results.json';
+var reportsDir = path.join(__dirname, '../../reports');
+var reportFile = path.join(reportsDir, 'cucumber-test-results.json');
 
 module.exports = function JsonOutputHook() {
   JsonFormatter.log = function (json) {
-    var destination = path.join(__dirname, reportFile);
-    fs.open(destination, 'w+', function (err, fd) {
+    fs.open(reportFile, 'w+', function (err, fd) {
       if (err) {
-        fs.mkdirsSync(destination);
-        fd = fs.openSync(destination, 'w+');
+        fs.mkdirsSync(reportsDir);
+        fd = fs.openSync(reportFile, 'w+');
       }
 
       fs.writeSync(fd, json);
 
-      console.log('json file location: ' + destination);
+      console.log('json file location: ' + reportFile);
     });
   };
 
@@ -174,22 +174,22 @@ This is all that's required to add the saved screenshots to the HTML report.
 In lieu of a formal styleguide, take care to maintain the existing coding style. Add unit tests for any new or changed functionality.
 
 ## Copyright
- 
+
 Copyright for portions of project [gulp-protractor-cucumber-html-report](https://github.com/mrooding/gulp-protractor-cucumber-html-report) are held by Robert Hilscher, 2015 as part of project [grunt-protractor-cucumber-html-report](https://github.com/robhil/grunt-protractor-cucumber-html-report). All other copyright for project [gulp-protractor-cucumber-html-report](https://github.com/mrooding/gulp-protractor-cucumber-html-report) are held by Marc Rooding, 2015.
 
 ## Release History
 0.0.9:
   - The readme now contains 2 different ways to use the JSON output hook. One using an external library and one without.
-  
+
 0.0.8:
   - Fix for not ignoring the After screenshot step
-  
+
 0.0.7:
   - Empty After steps as a result of the screenshot hook will not be added to the HTML report anymore
-  
+
 0.0.6:
   - Support for saving screenshots of failed scenarios
-  
+
 0.0.5:
   - More robust creation of the output directory [thanks smuldr!](https://github.com/smuldr)
   - Fixed the HTML reporter when using multiple feature files


### PR DESCRIPTION
There was a mistake in the code sample with fs-extra in README file: the parameter in `fs.mkdirsSync()` function should be a directory path and not a file path.
